### PR TITLE
Add analysis service

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Deploying GitLotus components
 
 This project's purpose is to enable the deployment of the complete GitLotus infrastructure as a `docker-compose` target. 
-The script starts all required components: [worker service](https://github.com/git2RDFLab/ccr-worker-prototype/), [SPARQL query service](https://github.com/git2RDFLab/sparql-query-prototype/), [listener service](https://github.com/git2RDFLab/ccr-listener-prototype/), and a [PostgreSQL database](https://www.postgresql.org/) for persistant data storage.
+The script starts all required components: [worker service](https://github.com/git2RDFLab/ccr-worker-prototype/), [SPARQL query service](https://github.com/git2RDFLab/sparql-query-prototype/), **analysis service**, [listener service](https://github.com/git2RDFLab/ccr-listener-prototype/), and a [PostgreSQL database](https://www.postgresql.org/) for persistant data storage.
 
 ## Deployment and executing all components
 
@@ -41,6 +41,24 @@ docker compose --env-file .env.local build --no-cache worker-service && \
 docker compose --env-file .env.local up -d worker-service
 `
 
+Restart only the query-service:
+
+`
+docker compose --env-file .env.local stop query-service && \
+docker compose --env-file .env.local rm -f query-service && \
+docker compose --env-file .env.local build --no-cache query-service && \
+docker compose --env-file .env.local up -d query-service
+`
+
+Restart only the analysis-service:
+
+`
+docker compose --env-file .env.local stop analysis-service && \
+docker compose --env-file .env.local rm -f analysis-service && \
+docker compose --env-file .env.local build --no-cache analysis-service && \
+docker compose --env-file .env.local up -d analysis-service
+`
+
 
 ```ShellSession
 git clone git@github.com:git2RDFLab/project-deployment-compose.git
@@ -64,6 +82,8 @@ docker compose --profile worker down -v
 http://localhost:8080/listener-service/swagger-ui/index.html
 * The API definitions of the SPARQL queries can be accessed via the Swagger UI of the [SPARQL query service](https://github.com/git2RDFLab/sparql-query-prototype/):<br/>
 http://localhost:7080/query-service/swagger-ui/index.html
+* The API definitions of the analysis results can be accessed via the Swagger UI of the analysis service:<br/>
+http://localhost:9080/analysis-service/swagger-ui/index.html
 
 ## Configuration
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,3 +78,19 @@ services:
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgresdb:5432/gitrdfdb
     profiles: ["no-worker", "worker"]
+
+  analysis-service:
+    platform: linux/arm64
+    build:
+      context: ../analysis
+      dockerfile: Dockerfile
+    image: git2rdf-analysis-service:1.0.0
+    depends_on:
+      - postgresdb
+      - listener-service
+    ports:
+      - "9080:8080"
+    environment:
+      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgresdb:5432/gitrdfdb
+    profiles: ["no-worker", "worker"]


### PR DESCRIPTION
## Summary
- deploy new analysis-service in docker-compose
- mention the analysis service in the README
- document how to rebuild query and analysis services like the worker

## Testing
- `docker compose config` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6872572e7e94832bb77433e6f37b418a